### PR TITLE
Progress bar on standard error.

### DIFF
--- a/WireLurkerDetectorOSX.py
+++ b/WireLurkerDetectorOSX.py
@@ -44,7 +44,7 @@ SUSPICIOUS_FILES = [
 
 def scan_files(paths):
     for f in paths:
-        sys.stdout.write('.')
+        sys.stderr.write('.')
         if os.path.exists(f):
             yield f
     print
@@ -99,7 +99,7 @@ def find_apps():
 
 def scan_app():
     for root in find_apps():
-        sys.stdout.write('.')
+        sys.stderr.write('.')
         if is_app_infected(root):
             yield root
     print


### PR DESCRIPTION
This will add a progress bar using '.' characters, using generators to report suspicious files as they are seen. This is printed on standard error to allow easier automation.

Compare with progress bar:

```
$ python WireLurkerDetectorOSX.py
WireLurker Detector (version 1.0.0)
Copyright (c) 2014, Palo Alto Networks, Inc.

[+] Scanning for known malicious files
.................
[-] Nothing is found.
[+] Scanning for known suspicious files
..
[-] Nothing is found.
[+] Scanning for infected applications (may take minutes)
....................................................................................................................................................................................
[-] Nothing is found.
[+] Your OS X system isn't infected by the WireLurker. Thank you!
```

To without progress bar:

``` shell
$ python WireLurkerDetectorOSX.py 2>/dev/null
WireLurker Detector (version 1.0.0)
Copyright (c) 2014, Palo Alto Networks, Inc.

[+] Scanning for known malicious files
[-] Nothing is found.
[+] Scanning for known suspicious files
[-] Nothing is found.
[+] Scanning for infected applications (may take minutes)
[-] Nothing is found.
[+] Your OS X system isn't infected by the WireLurker. Thank you!
```

See #11 for original pull request.
